### PR TITLE
feat(movies): Typ auf Film/Serie normalisieren, Medium als Tag-Dropdown

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "at.neuhaus.movieshelf"
         minSdk = 24
         targetSdk = 36
-        versionCode = 19
-        versionName = "1.7.0"
+        versionCode = 20
+        versionName = "1.8.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/at/neuhaus/movieshelf/ui/create/CreateMovieScreen.kt
+++ b/app/src/main/java/at/neuhaus/movieshelf/ui/create/CreateMovieScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
-private val COMMON_COLLECTION_TYPES = listOf("DVD", "Blu-ray", "4K UHD", "Digital", "Serie")
+// Kanonisches Schema wie in der Shelf: Typ = Film | Serie, das Medium steht im Tag.
+private val COMMON_COLLECTION_TYPES = listOf("Film", "Serie")
+private val MEDIA_TAGS = listOf("DVD", "BluRay", "4K", "Streaming", "Digital", "VHS", "Leihe")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -130,12 +132,10 @@ fun CreateMovieScreen(
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
                 )
-                OutlinedTextField(
+                TagDropdown(
                     value = viewModel.tag,
                     onValueChange = { viewModel.tag = it },
-                    label = { Text("Tag") },
-                    modifier = Modifier.weight(1f),
-                    singleLine = true
+                    modifier = Modifier.weight(1f)
                 )
             }
 
@@ -216,9 +216,53 @@ private fun CollectionTypeDropdown(
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            label = { Text("Sammlungstyp *") },
+            label = { Text("Typ *") },
             trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
             isError = value.isBlank(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TagDropdown(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = remember(value) {
+        (MEDIA_TAGS + value).filter { it.isNotBlank() }.distinct()
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text("Medium / Format") },
+            trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/at/neuhaus/movieshelf/ui/create/CreateMovieViewModel.kt
+++ b/app/src/main/java/at/neuhaus/movieshelf/ui/create/CreateMovieViewModel.kt
@@ -38,7 +38,7 @@ class CreateMovieViewModel : ViewModel() {
         when {
             title.isBlank() -> { error = "Titel darf nicht leer sein."; return }
             yearInt == null -> { error = "Bitte ein gültiges Jahr eingeben."; return }
-            collectionType.isBlank() -> { error = "Bitte einen Sammlungstyp wählen."; return }
+            collectionType.isBlank() -> { error = "Bitte einen Typ wählen."; return }
             rating.isNotBlank() && (ratingNum == null || ratingNum < 0 || ratingNum > 100) -> {
                 error = "Bewertung muss zwischen 0 und 100 liegen."; return
             }

--- a/app/src/main/java/at/neuhaus/movieshelf/ui/edit/EditMovieScreen.kt
+++ b/app/src/main/java/at/neuhaus/movieshelf/ui/edit/EditMovieScreen.kt
@@ -32,7 +32,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private val COMMON_COLLECTION_TYPES = listOf("DVD", "Blu-ray", "4K UHD", "Digital", "Serie")
+// Kanonisches Schema wie in der Shelf: Typ = Film | Serie, das Medium steht im Tag.
+private val COMMON_COLLECTION_TYPES = listOf("Film", "Serie")
+private val MEDIA_TAGS = listOf("DVD", "BluRay", "4K", "Streaming", "Digital", "VHS", "Leihe")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -214,12 +216,10 @@ fun EditMovieScreen(
                             singleLine = true,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
                         )
-                        OutlinedTextField(
+                        TagDropdown(
                             value = viewModel.tag,
                             onValueChange = { viewModel.tag = it },
-                            label = { Text("Tag") },
-                            modifier = Modifier.weight(1f),
-                            singleLine = true
+                            modifier = Modifier.weight(1f)
                         )
                     }
 
@@ -393,9 +393,54 @@ private fun CollectionTypeDropdown(
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            label = { Text("Sammlungstyp *") },
+            label = { Text("Typ *") },
             trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
             isError = value.isBlank(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TagDropdown(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    // Bestehenden Wert mit aufnehmen, falls er nicht in der Standardliste ist
+    val options = remember(value) {
+        (MEDIA_TAGS + value).filter { it.isNotBlank() }.distinct()
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text("Medium / Format") },
+            trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/at/neuhaus/movieshelf/ui/edit/EditMovieViewModel.kt
+++ b/app/src/main/java/at/neuhaus/movieshelf/ui/edit/EditMovieViewModel.kt
@@ -129,7 +129,7 @@ class EditMovieViewModel(
         when {
             title.isBlank() -> { error = "Titel darf nicht leer sein."; return }
             yearInt == null -> { error = "Bitte ein gültiges Jahr eingeben."; return }
-            collectionType.isBlank() -> { error = "Bitte einen Sammlungstyp wählen."; return }
+            collectionType.isBlank() -> { error = "Bitte einen Typ wählen."; return }
             rating.isNotBlank() && (ratingNum == null || ratingNum < 0 || ratingNum > 100) -> {
                 error = "Bewertung muss zwischen 0 und 100 liegen."; return
             }

--- a/app/src/main/java/at/neuhaus/movieshelf/ui/stats/StatsViewModel.kt
+++ b/app/src/main/java/at/neuhaus/movieshelf/ui/stats/StatsViewModel.kt
@@ -49,7 +49,7 @@ class StatsViewModel : ViewModel() {
             watched = WatchedStats(count = 2, percentage = 100.0),
             years = YearStats(avgYear = 2009.0, oldestYear = 2008, newestYear = 2010),
             collections = listOf(
-                CollectionStats(collectionType = "Blu-ray", count = 2, percentage = 100.0)
+                CollectionStats(collectionType = "Film", count = 2, percentage = 100.0)
             ),
             ratings = listOf(
                 RatingStats(ratingAge = 12, count = 1),


### PR DESCRIPTION
Gegenstück zu lunasans/MovieShelf-SaaS#11 und lunasans/movieshelf-desktop#54 (Shelf = Master).

## Zusammenfassung
Kanonisches Schema: `collection_type` = **Film** | **Serie**; das Medium (DVD, BluRay, 4K, Streaming, Digital, VHS, Leihe) steht ausschließlich im `tag`-Feld.

- Typ-Dropdown in CreateMovieScreen/EditMovieScreen: Vorschläge Film/Serie statt DVD/Blu-ray/4K UHD/Digital/Serie; Label "Typ" statt "Sammlungstyp"
- Tag: Freitextfeld durch Dropdown "Medium / Format" mit den Shelf-Werten ersetzt (bestehende Fremdwerte bleiben wählbar)
- Stats-Fallbackdaten von Blu-ray auf Film angepasst

Keine lokale Daten-Migration nötig: Die App ist API-Client der Shelf, der Room-Cache übernimmt die normalisierten Werte beim nächsten Sync (Tenant-Migration liegt im Shelf-PR).

## Verifikation
- `gradlew compileDebugKotlin` BUILD SUCCESSFUL