### PR TITLE
ci(release): Play-Store-Workflow – signiertes Bundle in den Internal-Track

### DIFF
--- a/.github/workflows/play-release.yml
+++ b/.github/workflows/play-release.yml
@@ -1,0 +1,67 @@
+name: Play Store Release
+
+# Ausgelöst durch Tag "v*" (analog zum Desktop-Release-Flow) oder manuell.
+# Baut ein signiertes App Bundle und lädt es in den Internal-Track hoch;
+# die Promotion zu Beta/Produktion passiert bewusst manuell in der Play Console.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Unit-Tests
+        run: ./gradlew testDebugUnitTest --console=plain
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Upload-Keystore bereitstellen
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/upload.keystore"
+
+      - name: Signiertes App Bundle bauen
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ runner.temp }}/upload.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease --console=plain
+
+      - name: In Play Store hochladen (Internal-Track)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: at.neuhaus.movieshelf
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
+
+      - name: App Bundle als Workflow-Artefakt sichern
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: app/build/outputs/bundle/release/app-release.aab

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Play-Store-Release (CI)
+
+Der Workflow [`play-release.yml`](.github/workflows/play-release.yml) baut bei einem
+Tag-Push `v*` (oder manuell über *Run workflow*) ein signiertes App Bundle und lädt es
+in den **Internal-Track** der Play Console hoch. Die Promotion zu Beta/Produktion
+bleibt ein manueller Schritt in der Play Console.
+
+## Ablauf pro Release
+
+1. `versionCode` erhöhen und `versionName` setzen in `app/build.gradle.kts`
+2. Committen, Tag `vX.Y.Z` setzen und pushen
+3. CI: Unit-Tests → `bundleRelease` (signiert) → Upload in den Internal-Track
+4. In der Play Console testen und manuell promoten
+
+## Einmalige Einrichtung (GitHub-Secrets)
+
+Der Workflow braucht fünf Repository-Secrets (*Settings → Secrets and variables → Actions*):
+
+| Secret | Inhalt |
+|--------|--------|
+| `ANDROID_KEYSTORE_BASE64` | Upload-Keystore, base64-kodiert: `base64 -w0 upload.keystore` (PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload.keystore"))`) |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore-Passwort |
+| `ANDROID_KEY_ALIAS` | Alias des Upload-Keys im Keystore |
+| `ANDROID_KEY_PASSWORD` | Passwort des Keys |
+| `PLAY_SERVICE_ACCOUNT_JSON` | JSON-Key des Google-Cloud-Service-Accounts (kompletter Dateiinhalt) |
+
+### Service-Account für die Play-API anlegen
+
+1. In der [Google Cloud Console](https://console.cloud.google.com/) ein Projekt wählen/anlegen
+   und die **Google Play Android Developer API** aktivieren
+2. Service-Account erstellen (*IAM & Verwaltung → Dienstkonten*), JSON-Key herunterladen
+3. In der [Play Console](https://play.google.com/console) unter
+   *Nutzer und Berechtigungen → Nutzer einladen* die Service-Account-E-Mail einladen und
+   der App `at.neuhaus.movieshelf` die Berechtigung **Releases in Tests-Tracks verwalten**
+   (oder *Releases verwalten*) geben
+4. Kompletten JSON-Inhalt als Secret `PLAY_SERVICE_ACCOUNT_JSON` hinterlegen
+
+### Keystore
+
+Es muss derselbe **Upload-Key** sein, der in der Play Console für die App registriert ist
+(bei aktiviertem Play App Signing signiert Google das finale Artefakt). Der Keystore wird
+nur base64-kodiert als Secret gespeichert und liegt nie im Repo.
+
+## Hinweise
+
+- Die Signier-Konfiguration in `app/build.gradle.kts` greift nur, wenn die CI
+  `ANDROID_KEYSTORE_FILE` setzt — lokale Builds über den Android-Studio-Wizard
+  funktionieren unverändert.
+- Track ändern: `track: internal` im Workflow auf `beta`/`production` stellen
+  (empfohlen: bei `internal` bleiben und manuell promoten).
+- Release-Notes können später über ein `whatsNewDirectory` ergänzt werden
+  (siehe Doku von `r0adkll/upload-google-play`).
+- Voraussetzung: Die App muss einmal manuell in der Play Console angelegt und ein
+  erstes Bundle hochgeladen worden sein — die API kann keine neue App erstellen.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,21 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // CI-Signierung: Der Play-Release-Workflow stellt den Upload-Keystore über
+    // Umgebungsvariablen bereit. Lokale Builds (Android-Studio-Wizard) bleiben
+    // unverändert, weil die Config nur bei gesetztem ANDROID_KEYSTORE_FILE greift.
+    val ciKeystorePath: String? = System.getenv("ANDROID_KEYSTORE_FILE")
+    if (ciKeystorePath != null) {
+        signingConfigs {
+            create("release") {
+                storeFile = file(ciKeystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
@@ -34,6 +49,9 @@ android {
                 // (ML Kit, CameraX). SYMBOL_TABLE extrahiert die noch vorhandene
                 // Symboltabelle; FULL fände keine Debug-Infos. Erfordert installiertes NDK.
                 debugSymbolLevel = "SYMBOL_TABLE"
+            }
+            if (ciKeystorePath != null) {
+                signingConfig = signingConfigs.getByName("release")
             }
         }
     }


### PR DESCRIPTION
## Zusammenfassung
Neuer GitHub-Actions-Workflow `play-release.yml`: Ein Tag-Push `v*` (oder manueller Start) läuft Unit-Tests, baut ein signiertes App Bundle (`bundleRelease`) und lädt es per Google-Play-API in den **Internal-Track** hoch (inkl. R8-Mapping für die Crash-Deobfuskierung). Die Promotion zu Beta/Produktion bleibt manuell in der Play Console.

- Signier-Konfiguration in `app/build.gradle.kts` ist rein CI-gesteuert (greift nur bei gesetztem `ANDROID_KEYSTORE_FILE`) — lokale Builds über den Android-Studio-Wizard bleiben unverändert
- `RELEASING.md` dokumentiert die einmalige Einrichtung: fünf Repository-Secrets (Keystore base64 + Passwörter, Play-Service-Account-JSON) und das Anlegen des Service-Accounts inkl. Play-Console-Berechtigung
- Das gebaute Bundle wird zusätzlich als Workflow-Artefakt gesichert

## Voraussetzungen (einmalig, manuell)
Ohne die fünf Secrets schlägt der Release-Job beim Signieren/Upload fehl — Details in RELEASING.md. Die App muss in der Play Console bereits existieren (die API kann keine neue App anlegen).

## Verifikation
- `gradlew compileDebugKotlin` ohne CI-Umgebungsvariablen: BUILD SUCCESSFUL (Signing-Config inaktiv, lokales Verhalten unverändert)
- Der Upload-Schritt selbst ist erst mit hinterlegten Secrets testbar — empfohlener Erstlauf über *Run workflow* (workflow_dispatch)