### PR TITLE
Kommentar zur Cover-Kachel richtigstellen

### DIFF
--- a/resources/views/tenant/actors/show.blade.php
+++ b/resources/views/tenant/actors/show.blade.php
@@ -203,7 +203,7 @@
                                         @if($movie->cover_url)
                                             <img src="{{ $movie->cover_url }}" alt="{{ $movie->title }}" class="w-full h-full object-cover">
                                         @else
-                                            {{-- Ohne Platzhalter waere ein Film ohne Cover hier unsichtbar --}}
+                                            {{-- Ohne Cover blieb die Kachel leer: der Titel stand nur im alt-Attribut des Bildes --}}
                                             <div class="w-full h-full flex items-center justify-center">
                                                 <i class="bi bi-film text-3xl text-white/10"></i>
                                             </div>


### PR DESCRIPTION
Reine Korrektur einer Begründung — am Verhalten ändert sich nichts.

Der Kommentar in `resources/views/tenant/actors/show.blade.php` behauptete, ein Film ohne Cover sei zuvor „unsichtbar" gewesen. Das stimmt nicht:

```blade
<a href="...">                                  ← Link, immer gerendert
    <div class="aspect-[2/3] ... glass border ...">   ← Kachel, immer gerendert
        @if($movie->cover_url) <img ...> @endif       ← nur das Bild war bedingt
    </div>
</a>
```

Das äussere `div` steht ausserhalb der Cover-Abfrage, und `.glass` bringt Hintergrund, Rahmen und Schatten mit. Die Kachel war also da und anklickbar — sie war **leer und nicht identifizierbar**, weil der Titel allein im `alt`-Attribut des fehlenden Bildes stand.

Die Ergänzung aus #87 (Platzhalter-Icon, Titel, Jahr) bleibt richtig und unverändert; nur die Begründung im Kommentar war es nicht.

Entstanden ist der Fehler daraus, dass ich aus einem fehlgeschlagenen `assertSee('Test Movie')` auf die ganze Kachel geschlossen habe statt nur auf den Titel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)